### PR TITLE
Fix startup failure

### DIFF
--- a/src/startup_ch32v003.c
+++ b/src/startup_ch32v003.c
@@ -127,17 +127,17 @@ void handle_reset()
 
 	// Careful: Use registers to prevent overwriting of self-data.
 	// This clears out BSS.
-	register uint32_t * tempout = _sbss;
-	register uint32_t * tempend = _ebss;
+	register uint32_t * tempout = (uint32_t*)&_sbss;
+	register uint32_t * tempend = (uint32_t*)&_ebss;
 	while( tempout < tempend )
 		*(tempout++) = 0;
 
 	// Once we get here, it should be safe to execute regular C code.
 
 	// Load data section from flash to RAM 
-	register uint32_t * tempin = _data_lma;
-	tempout = _data_vma;
-	tempend = _edata;
+	register uint32_t * tempin = (uint32_t*)&_data_lma;
+	tempout = (uint32_t*)&_data_vma;
+	tempend = (uint32_t*)&_edata;
 	while( tempout != tempend )
 		*(tempout++) = *(tempin++); 
 


### PR DESCRIPTION
Due to some peculiar way in which the variables created in the linker script are accessed in the C code, the C code got the wrong values for `tempout = _sbss;` etc. The `_sbss` is created in the linker script as the start of the bss segment and was imported in the C code as 
```cpp
extern uint32_t* _sbss;
```
However, the code `tempout = _sbss;` first loaded the correct value for the start of the BSS segment, (_sbss, e.g. 0x2000000), then *dereferenced* the pointer immediately. Since RAM is not initialized at this point (and it wasn't supposed to do that dereference), `tempout` now had value that came from random RAM content, instead of the correct target pointer. This very quickly crashed the program.

This is fixed by doing `&_sbbs` instead.

This little nuance of referencing a linker-created variable (or the address thereof) might differ between compiler versions, explaining why it worked with other RISC-V toolchains.

With just this fix, the firmware reaches the `main()` function just fine and it printfs() correctly to the UART.

![grafik](https://github.com/MUSTARDTIGERFPV/ch32-hardfault/assets/26485477/2f754e95-fc32-45fe-8632-762798ffdaa1)

The original file at https://github.com/cnlohr/ch32v003fun/blob/master/attic/ch32v003evt/startup_ch32v003.c might need fixing too.  Though I'm not sure if you are supposed to use that in the first place.. Either the real WCH EVT / SDK or CH32V003fun is what I'd recommend. Not the **Attic** files.
